### PR TITLE
add canary tests and update unit tests for new simbad

### DIFF
--- a/simbad2k/simbad2k.py
+++ b/simbad2k/simbad2k.py
@@ -72,7 +72,7 @@ class SimbadQuery(object):
         result = self.simbad.query_object(self.query)
         if result:
             ret_dict = {}
-            for key in ['RA', 'DEC', 'RA_d', 'DEC_d', 'PMRA', 'PMDEC', 'PLX_VALUE', 'MAIN_ID']:
+            for key in ['pmra', 'pmdec', 'ra', 'dec', 'plx_value', 'main_id']:
                 if str(result[key][0]) not in ['--', '']:
                     ret_dict[key.lower()] = result[key][0]
             if ret_dict.get('main_id'):

--- a/simbad2k/tests/canary_tests_simbad2k.py
+++ b/simbad2k/tests/canary_tests_simbad2k.py
@@ -20,6 +20,49 @@ def client():
     simbad2k.cache.clear()
 
 
+class TestSimbad:
+    def test_random_star(self, client):
+        query  = 'HD 289002'
+        expected_name = 'HD 289002'
+        expected_ra = 101.30571895498
+        expected_dec = 2.13741256961
+        expected_paralax = 0.4561
+        precision = 3 # make sure the position is good to ~1 arcsecond
+        simbad_response = client.get(f'/{query}?target_type=sidereal').json
+        assert simbad_response['name'] == expected_name
+        assert round(simbad_response['ra'], precision) == round(expected_ra, precision)
+        assert round(simbad_response['dec'], precision) == round(expected_dec, precision)
+        assert round(simbad_response['plx_value'], precision) == round(expected_paralax, precision)
+
+
+    def test_named_star(self, client):
+        query  = 'Polaris'
+        expected_name = '* alf UMi'
+        expected_ra = 37.95456067018985
+        expected_dec = 89.26410896994187
+        expected_paralax = 7.54
+        precision = 3 # make sure the position is good to ~1 arcsecond
+        simbad_response = client.get(f'/{query}?target_type=sidereal').json
+        assert simbad_response['name'] == expected_name
+        assert round(simbad_response['ra'], precision) == round(expected_ra, precision)
+        assert round(simbad_response['dec'], precision) == round(expected_dec, precision)
+        assert round(simbad_response['plx_value'], precision) == round(expected_paralax, precision)
+
+
+    def test_messier_object(self, client):
+        query  = 'M55'
+        expected_name = 'M  55'
+        expected_ra = 294.9987916666667
+        expected_dec = -30.96475
+        expected_paralax = 0.209
+        precision = 3  # make sure the position is good to ~1 arcsecond
+        simbad_response = client.get(f'/{query}?target_type=sidereal').json
+        assert simbad_response['name'] == expected_name
+        assert round(simbad_response['ra'], precision) == round(expected_ra, precision)
+        assert round(simbad_response['dec'], precision) == round(expected_dec, precision)
+        assert round(simbad_response['plx_value'], precision) == round(expected_paralax, precision)
+
+
 class TestMPC:
     def test_named_asteroid(self, client):
         query  = 'Ceres'

--- a/simbad2k/tests/test_simbad2k.py
+++ b/simbad2k/tests/test_simbad2k.py
@@ -43,8 +43,9 @@ def mock_simbad_response():
     # Return an astroquery Simbad response that has no results, where results can be added in the tests. The astroquery
     # Simbad query returns an astropy.table.Table
     table = Table(
-        names=('RA', 'DEC', 'RA_d', 'DEC_d', 'PMRA', 'PMDEC', 'PLX_VALUE', 'MAIN_ID'),
-        dtype=('S', 'S', 'f8', 'f8', 'f8', 'f8', 'f8', 'S')
+        names=('main_id', 'ra', 'dec', 'coo_err_maj', 'coo_err_min', 'coo_err_angle', 'coo_wavelength', 'coo_bibcode',
+               'pmdec', 'plx_value', 'pmra', 'matched_id'),
+        dtype=('S', 'f8', 'f8', 'f8', 'f8', 'f8', 'f8', 'S', 'f8', 'f8', 'f8', 'S')
     )
     return table
 
@@ -75,14 +76,12 @@ def mock_astroquery_query(monkeypatch, mock_mpc_response, mock_ned_response, moc
 @pytest.fixture
 def m88_simbad_table_row():
     return {
-        'RA': '12 31 59.216',
-        'DEC': '+14 25 13.48',
-        'RA_d': '187.996733',
-        'DEC_d': '14.420411',
-        'PMRA': None,
-        'PMDEC': None,
-        'PLX_VALUE': None,
-        'MAIN_ID': 'M  88'
+        'ra': 187.996733,
+        'dec': 14.420411,
+        'pmra': None,
+        'pmdec': None,
+        'plx_value': None,
+        'main_id': 'M  88'
     }
 
 
@@ -136,9 +135,9 @@ def test_sidereal_simbad_target(client, mock_simbad_response, m88_simbad_table_r
     response = client.get('/m88?target_type=sidereal')
     assert response.is_json
     response_json = response.get_json()
-    assert response_json['ra'] == m88_simbad_table_row['RA']
-    assert response_json['dec'] == m88_simbad_table_row['DEC']
-    assert response_json['name'] == m88_simbad_table_row['MAIN_ID']
+    assert response_json['ra'] == m88_simbad_table_row['ra']
+    assert response_json['dec'] == m88_simbad_table_row['dec']
+    assert response_json['name'] == m88_simbad_table_row['main_id']
 
 
 def test_successfully_retrieved_result_is_cached(client, mock_simbad_response, m88_simbad_table_row):


### PR DESCRIPTION
Previous tests mocked simbad returns and didn't have any canary tests, so we were not sensitive to the recent astroquery updates.

There should be one more astroquery release to [fix a bug with table joins](https://github.com/astropy/astroquery/pull/3199) in the near future, but that shouldn't affect this PR.